### PR TITLE
fix(tsconfig): set `moduleResolution` to `node` in bot app

### DIFF
--- a/apps/bot/tsconfig.json
+++ b/apps/bot/tsconfig.json
@@ -9,7 +9,7 @@
     "paths": {
       "src/*": ["./*"]
     },
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "allowImportingTsExtensions": true,
     "preserveSymlinks": true,
     "esModuleInterop": true,


### PR DESCRIPTION
The old `moduleResolution` caused import paths to break. 