### PR TITLE
feat(cmd): add warn commands

### DIFF
--- a/apps/bot/src/commands/buttons/settings/s_ntf.ts
+++ b/apps/bot/src/commands/buttons/settings/s_ntf.ts
@@ -31,7 +31,7 @@ export const run = async ({ bot, interaction, hexColor, db }: ButtonInteractionP
     .addSeparatorComponents((separator) => separator)
     .addTextDisplayComponents((textDisplay) =>
       textDisplay.setContent(
-        `**bump reminder channel**\n${server.notificationSettings?.bumpChannel ? `<#${server.notificationSettings.bumpChannel}>` : "none"}`,
+        `**bump reminder channel**\n${server.notificationSettings?.bumpChannel ? `<#${server.notificationSettings.bumpChannel}>` : "none"}\n\n**moderation channel**\n${server.notificationSettings?.moderationChannel ? `<#${server.notificationSettings.moderationChannel}>` : "none"}`,
       ),
     )
     .addActionRowComponents((actionRow) => actionRow.setComponents(returnButton))

--- a/apps/bot/src/commands/buttons/settings/s_ntf_edit.ts
+++ b/apps/bot/src/commands/buttons/settings/s_ntf_edit.ts
@@ -12,19 +12,30 @@ import { run as runSettings } from "./s_ntf"
 
 enum InteractionIds {
   BUMP_CHANNEL_SELECT = "ntf_bump_channel_select",
+  MODERATION_CHANNEL_SELECT = "ntf_moderation_channel_select",
   NOTIFICATION_CONFIRM = "ntf_confirm-ignore",
 }
 
 export const run = async ({ bot, interaction, hexColor, db }: ButtonInteractionProps<"cached">) => {
   let server = await db.servers.getOrCreateServerByDiscordId(interaction.guild.id)
   let bumpChannelId: string | null = null
+  let moderationChannelId: string | null = null
 
-  const channelSelector = new ChannelSelectMenuBuilder()
+  const bumpChannelSelector = new ChannelSelectMenuBuilder()
     .setCustomId(InteractionIds.BUMP_CHANNEL_SELECT)
     .setChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement)
     .setPlaceholder(
       server.notificationSettings?.bumpChannel
         ? `#${interaction.guild.channels.cache.get(server.notificationSettings.bumpChannel)?.name ?? "configured channel"}`
+        : "select channel",
+    )
+
+  const moderationChannelSelector = new ChannelSelectMenuBuilder()
+    .setCustomId(InteractionIds.MODERATION_CHANNEL_SELECT)
+    .setChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement)
+    .setPlaceholder(
+      server.notificationSettings?.moderationChannel
+        ? `#${interaction.guild.channels.cache.get(server.notificationSettings.moderationChannel)?.name ?? "configured channel"}`
         : "select channel",
     )
 
@@ -49,7 +60,11 @@ export const run = async ({ bot, interaction, hexColor, db }: ButtonInteractionP
     .addTextDisplayComponents((textDisplay) =>
       textDisplay.setContent("**configure the channel for bump reminders**"),
     )
-    .addActionRowComponents((actionRow) => actionRow.setComponents(channelSelector))
+    .addActionRowComponents((actionRow) => actionRow.setComponents(bumpChannelSelector))
+    .addTextDisplayComponents((textDisplay) =>
+      textDisplay.setContent("**configure the channel for moderation actions**"),
+    )
+    .addActionRowComponents((actionRow) => actionRow.setComponents(moderationChannelSelector))
     .addActionRowComponents((actionRow) => actionRow.setComponents(confirmButton, cancelButton))
 
   const message = await interaction.editReply({
@@ -65,12 +80,16 @@ export const run = async ({ bot, interaction, hexColor, db }: ButtonInteractionP
     if (i.isChannelSelectMenu() && i.customId === InteractionIds.BUMP_CHANNEL_SELECT) {
       bumpChannelId = i.values[0] ?? null
       await i.deferUpdate()
+    } else if (i.isChannelSelectMenu() && i.customId === InteractionIds.MODERATION_CHANNEL_SELECT) {
+      moderationChannelId = i.values[0] ?? null
+      await i.deferUpdate()
     } else if (i.isButton() && i.customId === InteractionIds.NOTIFICATION_CONFIRM) {
       server = await db.servers.getOrCreateServerByDiscordId(interaction.guild.id)
 
       await db.servers.updateServerById(server.id, {
         notificationSettings: {
           bumpChannel: bumpChannelId ?? server.notificationSettings?.bumpChannel,
+          moderationChannel: moderationChannelId ?? server.notificationSettings?.moderationChannel,
         },
       })
 

--- a/apps/bot/src/commands/buttons/settings/s_return.ts
+++ b/apps/bot/src/commands/buttons/settings/s_return.ts
@@ -42,9 +42,7 @@ export const run = async ({ interaction, hexColor }: ButtonInteractionProps<"cac
     .addSectionComponents((section) =>
       section
         .addTextDisplayComponents((textDisplay) =>
-          textDisplay.setContent(
-            "**notification settings**\n-# configure channels for bump reminders and other server notifications",
-          ),
+          textDisplay.setContent("**notification settings**\n-# configure log channels"),
         )
         .setButtonAccessory((button) =>
           button

--- a/apps/bot/src/commands/text/mod/clearwarn.ts
+++ b/apps/bot/src/commands/text/mod/clearwarn.ts
@@ -30,6 +30,25 @@ export const run = async ({ bot, message, args, db, color }: BaseCommandProps<tr
     .setColor(color)
     .setTimestamp()
 
+  let failedToDm = false
+  await member
+    .send({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle("warnings cleared")
+          .setDescription(
+            `your ${clearedWarnings.docs.length} warning${clearedWarnings.docs.length === 1 ? " has" : "s have"} been cleared in **${message.guild.name}**.`,
+          )
+          .setColor(color)
+          .setTimestamp(),
+      ],
+      allowedMentions: {},
+    })
+    .catch(() => {
+      failedToDm = true
+      clearedEmbed.setFooter({ text: "failed to dm" })
+    })
+
   const clearedSummary = clearedWarnings.docs
     .map((warning) => `${warning.id} | ${warning.reason || "no reason provided"}`)
     .join("\n")
@@ -38,7 +57,9 @@ export const run = async ({ bot, message, args, db, color }: BaseCommandProps<tr
   const logChannelId = await sendModerationLog(message, db, {
     embeds: [
       EmbedBuilder.from(clearedEmbed)
-        .setFooter({ text: `cleared by: ${message.author.tag} (${message.author.id})` })
+        .setFooter({
+          text: `cleared by: ${message.author.tag} (${message.author.id})${failedToDm ? " | failed to dm" : ""}`,
+        })
         .addFields({ name: "warnings cleared", value: clearedSummary }),
     ],
     allowedMentions: {},

--- a/apps/bot/src/commands/text/mod/clearwarn.ts
+++ b/apps/bot/src/commands/text/mod/clearwarn.ts
@@ -1,0 +1,65 @@
+import { EmbedBuilder } from "discord.js"
+import type { BaseCommandConfig, BaseCommandProps } from "@/types/command"
+import { createSimpleEmbed } from "@/utils/embeds"
+import { sendModerationLog } from "@/utils/moderation"
+import { getMember } from "@/utils/parsers"
+
+export const run = async ({ bot, message, args, db, color }: BaseCommandProps<true>) => {
+  const member = getMember({ message, toFind: args[0], excludeSelf: true })
+  if (!member)
+    return message.reply({
+      embeds: [createSimpleEmbed("you must mention a user to clear their warnings!", color)],
+      allowedMentions: { repliedUser: false },
+    })
+
+  const warnings = await db.warns.getServerWarns(message.guild.id, member.id)
+
+  if (!warnings.length)
+    return message.reply({
+      embeds: [createSimpleEmbed(`${member} has no warnings to clear!`, color)],
+      allowedMentions: { repliedUser: false },
+    })
+
+  const clearedWarnings = await db.warns.clearUserWarns(message.guild.id, member.id)
+
+  const clearedEmbed = new EmbedBuilder()
+    .setTitle("warns cleared")
+    .setDescription(
+      `${bot.config.emojis.placeholder} cleared ${clearedWarnings.docs.length} warning${clearedWarnings.docs.length === 1 ? "" : "s"} for ${member}.`,
+    )
+    .setColor(color)
+    .setTimestamp()
+
+  const clearedSummary = clearedWarnings.docs
+    .map((warning) => `${warning.id} | ${warning.reason || "no reason provided"}`)
+    .join("\n")
+    .slice(0, 1024)
+
+  const logChannelId = await sendModerationLog(message, db, {
+    embeds: [
+      EmbedBuilder.from(clearedEmbed)
+        .setFooter({ text: `cleared by: ${message.author.tag} (${message.author.id})` })
+        .addFields({ name: "warnings cleared", value: clearedSummary }),
+    ],
+    allowedMentions: {},
+  })
+
+  if (message.channel.id !== logChannelId) {
+    return message.channel.send({
+      embeds: [clearedEmbed],
+      allowedMentions: {},
+    })
+  }
+}
+
+export const config: BaseCommandConfig = {
+  name: "clearwarn",
+  description: "clears all warnings for a member",
+  usage: ["clearwarn <user>"],
+  aliases: ["clearwarns", "cwarn", "cwarns"],
+  cooldown: 1,
+  permissionSet: {
+    guildOnly: true,
+    userPermissionsRequired: ["ManageMessages"],
+  },
+}

--- a/apps/bot/src/commands/text/mod/finalwarn.ts
+++ b/apps/bot/src/commands/text/mod/finalwarn.ts
@@ -1,0 +1,107 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } from "discord.js"
+import type { BaseCommandConfig, BaseCommandProps } from "@/types/command"
+import { createSimpleEmbed } from "@/utils/embeds"
+import { sendModerationLog } from "@/utils/moderation"
+import { getMember } from "@/utils/parsers"
+
+export const run = async ({ bot, message, args, db, color, prefix }: BaseCommandProps<true>) => {
+  const member = getMember({ message, toFind: args[0], excludeSelf: true })
+  if (!member || member.user.bot)
+    return message.reply({
+      embeds: [createSimpleEmbed("you must mention a valid member to final warn!", color)],
+      allowedMentions: { repliedUser: false },
+    })
+
+  const reason = args.slice(1).join(" ").trim()
+  if (!reason)
+    return message.reply({
+      embeds: [
+        createSimpleEmbed(
+          `you must provide a reason! e.g. ${prefix}finalwarn <user> <reason>`,
+          color,
+        ),
+      ],
+      allowedMentions: { repliedUser: false },
+    })
+
+  if (await db.warns.hasFinalWarn(message.guild.id, member.id)) {
+    return message.reply({
+      embeds: [createSimpleEmbed(`${member} is already on their final warning!`, color)],
+      allowedMentions: { repliedUser: false },
+    })
+  }
+
+  const warning = await db.warns.createWarn({
+    reason,
+    by: message.author.id,
+    to: member.id,
+    server: message.guild.id,
+    final: true,
+  })
+  const warningCount = (await db.warns.getServerWarns(message.guild.id, member.id)).length
+
+  await message.delete().catch(() => {})
+
+  const warningEmbed = new EmbedBuilder()
+    .setTitle(`${bot.config.emojis.final_warning} final warning`)
+    .setDescription(
+      `${bot.config.emojis.placeholder} ${member} **has been warned:** "${reason}"
+      **this is your final warning!** further breaking of rules **will** result in a ban.`,
+    )
+    .setFooter({
+      text: `${member.user.tag} has ${warningCount} warning${warningCount === 1 ? "" : "s"} (warning id: ${warning.id})`,
+    })
+    .setColor(color)
+    .setTimestamp()
+
+  let failedToDm = false
+  await member
+    .send({
+      embeds: [warningEmbed],
+      components: [
+        new ActionRowBuilder<ButtonBuilder>().addComponents(
+          new ButtonBuilder()
+            .setDisabled(true)
+            .setStyle(ButtonStyle.Secondary)
+            .setLabel(`sent from ${message.guild.name}`.slice(0, 80))
+            .setCustomId("warning_source"),
+        ),
+      ],
+      allowedMentions: {},
+    })
+    .catch(() => {
+      failedToDm = true
+    })
+
+  if (failedToDm) {
+    warningEmbed.setFooter({
+      text: `${member.user.tag} has ${warningCount} warning${warningCount === 1 ? "" : "s"} (warning id: ${warning.id}) | failed to dm`,
+    })
+  }
+
+  const logChannelId = await sendModerationLog(message, db, {
+    embeds: [
+      EmbedBuilder.from(warningEmbed).addFields({ name: "warned by", value: `${message.author}` }),
+    ],
+    allowedMentions: {},
+  })
+
+  if (message.channel.id !== logChannelId) {
+    return message.channel.send({
+      embeds: [warningEmbed],
+      allowedMentions: {},
+    })
+  }
+}
+
+export const config: BaseCommandConfig = {
+  name: "finalwarn",
+  description: "gives a member their final warning",
+  usage: ["finalwarn <user> <reason>"],
+  aliases: ["fwarn"],
+  cooldown: 1,
+  permissionSet: {
+    guildOnly: true,
+    userPermissionsRequired: ["ManageMessages"],
+  },
+}

--- a/apps/bot/src/commands/text/mod/removewarn.ts
+++ b/apps/bot/src/commands/text/mod/removewarn.ts
@@ -32,10 +32,36 @@ export const run = async ({ bot, message, args, db, color }: BaseCommandProps<tr
     .setColor(color)
     .setTimestamp()
 
+  let failedToDm = false
+  await bot.users
+    .fetch(warning.to)
+    .then((user) =>
+      user.send({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle("warning removed")
+            .setDescription(
+              `your ${warning.final ? "final " : ""}warning \`${warning.id}\` has been removed in **${message.guild.name}**.`,
+            )
+            .addFields({
+              name: "reason",
+              value: (warning.reason || "no reason provided").slice(0, 1024),
+            })
+            .setColor(color)
+            .setTimestamp(),
+        ],
+        allowedMentions: {},
+      }),
+    )
+    .catch(() => {
+      failedToDm = true
+      removedEmbed.setFooter({ text: "failed to dm" })
+    })
+
   const logChannelId = await sendModerationLog(message, db, {
     embeds: [
       EmbedBuilder.from(removedEmbed).setFooter({
-        text: `removed by: ${message.author.tag} (${message.author.id})`,
+        text: `removed by: ${message.author.tag} (${message.author.id})${failedToDm ? " | failed to dm" : ""}`,
       }),
     ],
     allowedMentions: {},

--- a/apps/bot/src/commands/text/mod/removewarn.ts
+++ b/apps/bot/src/commands/text/mod/removewarn.ts
@@ -1,0 +1,62 @@
+import { EmbedBuilder } from "discord.js"
+import type { BaseCommandConfig, BaseCommandProps } from "@/types/command"
+import { createSimpleEmbed } from "@/utils/embeds"
+import { sendModerationLog } from "@/utils/moderation"
+
+export const run = async ({ bot, message, args, db, color }: BaseCommandProps<true>) => {
+  const warningId = args[0]?.trim()
+  if (!warningId) {
+    return message.reply({
+      embeds: [createSimpleEmbed("you must provide a warning id to remove!", color)],
+      allowedMentions: { repliedUser: false },
+    })
+  }
+
+  const warning = await db.warns.removeServerWarn(message.guild.id, warningId)
+  if (!warning) {
+    return message.reply({
+      embeds: [createSimpleEmbed(`warning \`${warningId}\` could not be found!`, color)],
+      allowedMentions: { repliedUser: false },
+    })
+  }
+
+  const removedEmbed = new EmbedBuilder()
+    .setTitle("warning removed")
+    .setDescription(
+      `${bot.config.emojis.placeholder} removed ${warning.final ? "final " : ""}warning \`${warning.id}\` from <@${warning.to}>.`,
+    )
+    .addFields({
+      name: "reason",
+      value: (warning.reason || "no reason provided").slice(0, 1024),
+    })
+    .setColor(color)
+    .setTimestamp()
+
+  const logChannelId = await sendModerationLog(message, db, {
+    embeds: [
+      EmbedBuilder.from(removedEmbed).setFooter({
+        text: `removed by: ${message.author.tag} (${message.author.id})`,
+      }),
+    ],
+    allowedMentions: {},
+  })
+
+  if (message.channel.id !== logChannelId) {
+    return message.channel.send({
+      embeds: [removedEmbed],
+      allowedMentions: {},
+    })
+  }
+}
+
+export const config: BaseCommandConfig = {
+  name: "removewarn",
+  description: "removes a warning by its id",
+  usage: ["removewarn <warning id>"],
+  aliases: ["deletewarn", "delwarn", "rwarn"],
+  cooldown: 1,
+  permissionSet: {
+    guildOnly: true,
+    userPermissionsRequired: ["ManageMessages"],
+  },
+}

--- a/apps/bot/src/commands/text/mod/settings.ts
+++ b/apps/bot/src/commands/text/mod/settings.ts
@@ -42,9 +42,7 @@ export const run = async ({ message, hexColor }: BaseCommandProps<true>) => {
     .addSectionComponents((section) =>
       section
         .addTextDisplayComponents((textDisplay) =>
-          textDisplay.setContent(
-            "**notification settings**\n-# configure channels for bump reminders and other server notifications",
-          ),
+          textDisplay.setContent("**notification settings**\n-# configure log channels"),
         )
         .setButtonAccessory((button) =>
           button

--- a/apps/bot/src/commands/text/mod/warn.ts
+++ b/apps/bot/src/commands/text/mod/warn.ts
@@ -1,0 +1,104 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } from "discord.js"
+import type { BaseCommandConfig, BaseCommandProps } from "@/types/command"
+import { createSimpleEmbed } from "@/utils/embeds"
+import { sendModerationLog } from "@/utils/moderation"
+import { getMember } from "@/utils/parsers"
+
+export const run = async ({ bot, message, args, db, color }: BaseCommandProps<true>) => {
+  const member = getMember({ message, toFind: args[0], excludeSelf: true })
+  if (!member || member.user.bot)
+    return message.reply({
+      embeds: [createSimpleEmbed("you must mention a valid user to warn!", color)],
+      allowedMentions: { repliedUser: false },
+    })
+
+  const reason = args.slice(1).join(" ").trim()
+  if (!reason)
+    return message.reply({
+      embeds: [createSimpleEmbed("you must provide a reason!", color)],
+      allowedMentions: { repliedUser: false },
+    })
+
+  if (await db.warns.hasFinalWarn(message.guild.id, member.id)) {
+    return message.reply({
+      embeds: [
+        createSimpleEmbed(
+          `${member} is on their final warning, you can't warn them any more!`,
+          color,
+        ),
+      ],
+      allowedMentions: { repliedUser: false },
+    })
+  }
+
+  const warning = await db.warns.createWarn({
+    reason,
+    by: message.author.id,
+    to: member.id,
+    server: message.guild.id,
+    final: false,
+  })
+  const warningCount = (await db.warns.getServerWarns(message.guild.id, member.id)).length
+
+  await message.delete().catch(() => {})
+
+  const warningEmbed = new EmbedBuilder()
+    .setTitle(`${bot.config.emojis.warning} warning`)
+    .setDescription(`${bot.config.emojis.placeholder} ${member} **has been warned:** “${reason}”`)
+    .setFooter({
+      text: `${member.user.tag} has ${warningCount} warning${warningCount === 1 ? "" : "s"} (warning id: ${warning.id})`,
+    })
+    .setColor(color)
+    .setTimestamp()
+
+  let failedToDm = false
+  await member
+    .send({
+      embeds: [warningEmbed],
+      components: [
+        new ActionRowBuilder<ButtonBuilder>().addComponents(
+          new ButtonBuilder()
+            .setDisabled(true)
+            .setStyle(ButtonStyle.Secondary)
+            .setLabel(`sent from ${message.guild.name}`.slice(0, 80))
+            .setCustomId("warning_source"),
+        ),
+      ],
+      allowedMentions: {},
+    })
+    .catch(() => {
+      failedToDm = true
+    })
+
+  if (failedToDm) {
+    warningEmbed.setFooter({
+      text: `${member.user.tag} has ${warningCount} warning${warningCount === 1 ? "" : "s"} (warning id: ${warning.id}) | failed to dm`,
+    })
+  }
+
+  const logChannelId = await sendModerationLog(message, db, {
+    embeds: [
+      EmbedBuilder.from(warningEmbed).addFields({ name: "warned by", value: `${message.author}` }),
+    ],
+    allowedMentions: {},
+  })
+
+  if (message.channel.id !== logChannelId) {
+    return message.channel.send({
+      embeds: [warningEmbed],
+      allowedMentions: {},
+    })
+  }
+}
+
+export const config: BaseCommandConfig = {
+  name: "warn",
+  description: "warns a member in the server",
+  usage: ["warn <user> <reason>"],
+  aliases: [],
+  cooldown: 1,
+  permissionSet: {
+    guildOnly: true,
+    userPermissionsRequired: ["ManageMessages"],
+  },
+}

--- a/apps/bot/src/commands/text/mod/warnings.ts
+++ b/apps/bot/src/commands/text/mod/warnings.ts
@@ -31,7 +31,7 @@ export const run = async ({ bot, message, args, db, color, prefix }: BaseCommand
         .addFields(
           {
             name: "warning commands",
-            value: `\`${prefix}warn <user> <reason>\` - warn a member\n\`${prefix}cwarn <user>\` - clear a member's warnings\n\`${prefix}fwarn <user> <reason>\` - give a final warning`,
+            value: `\`${prefix}warn <user> <reason>\` - warn a member\n\`${prefix}cwarn <user>\` - clear a member's warnings\n\`${prefix}rwarn <warning id>\` - remove a warning\n\`${prefix}fwarn <user> <reason>\` - give a final warning`,
           },
           {
             name: "formatting",

--- a/apps/bot/src/commands/text/mod/warnings.ts
+++ b/apps/bot/src/commands/text/mod/warnings.ts
@@ -1,0 +1,160 @@
+import { EmbedBuilder } from "discord.js"
+import ms, { type StringValue } from "ms"
+import type { BaseCommandConfig, BaseCommandProps } from "@/types/command"
+import { createSimpleEmbed } from "@/utils/embeds"
+import { getMember } from "@/utils/parsers"
+
+const WARNINGS_PER_PAGE = 9
+
+export const run = async ({ bot, message, args, db, color, prefix }: BaseCommandProps<true>) => {
+  const target = getMember({ message, toFind: args[0], excludeSelf: true, excludeNameSearch: true })
+  if (target?.user.bot)
+    return message.reply({
+      embeds: [createSimpleEmbed("bots don't have warnings!", color)],
+      allowedMentions: { repliedUser: false },
+    })
+
+  const flagArgs = target ? args.slice(1) : args
+  let pageNumber = 1
+  let pageWasSet = false
+  let olderThan: number | null = null
+  let newerThan: number | null = null
+  let finalOnly = false
+
+  for (let index = 0; index < flagArgs.length; index++) {
+    const argument = flagArgs[index]
+
+    if (["--help", "--h"].includes(argument)) {
+      const helpEmbed = new EmbedBuilder()
+        .setTitle("help: warnings")
+        .setDescription("shows warning history for this server or a specific member.")
+        .addFields(
+          {
+            name: "warning commands",
+            value: `\`${prefix}warn <user> <reason>\` - warn a member\n\`${prefix}cwarn <user>\` - clear a member's warnings\n\`${prefix}fwarn <user> <reason>\` - give a final warning`,
+          },
+          {
+            name: "formatting",
+            value: `\`${prefix}warnings <page>\` - show all warnings\n\`${prefix}warnings <user> <page>\` - show a member's warnings`,
+          },
+          {
+            name: "filters",
+            value:
+              "`--time < 24h` - warnings newer than 24 hours\n`--time > 7d` - warnings older than 7 days\n`--final` - final warnings only",
+          },
+        )
+        .setColor(color)
+
+      return message.reply({ embeds: [helpEmbed], allowedMentions: { repliedUser: false } })
+    }
+
+    if (["--time", "--t"].includes(argument)) {
+      const operator = flagArgs[index + 1]
+      const durationInput = flagArgs[index + 2]
+      const duration = durationInput ? ms(durationInput as StringValue) : undefined
+
+      if (!duration || !["<", ">"].includes(operator)) {
+        return message.reply({
+          embeds: [
+            createSimpleEmbed(
+              "invalid time filter. use `--time < 24h` for newer warnings or `--time > 7d` for older warnings.",
+              color,
+            ),
+          ],
+          allowedMentions: { repliedUser: false },
+        })
+      }
+
+      if (operator === ">") olderThan = Date.now() - duration
+      if (operator === "<") newerThan = Date.now() - duration
+      index += 2
+      continue
+    }
+
+    if (argument === "--final") {
+      finalOnly = true
+      continue
+    }
+
+    if (/^\d+$/.test(argument) && !pageWasSet) {
+      pageNumber = Number(argument)
+      pageWasSet = true
+    }
+  }
+
+  if (pageNumber < 1) {
+    return message.reply({
+      embeds: [createSimpleEmbed("page numbers must be greater than zero!", color)],
+      allowedMentions: { repliedUser: false },
+    })
+  }
+
+  const warnings = await db.warns.getServerWarns(message.guild.id, target?.id, {
+    olderThan: olderThan ?? undefined,
+    newerThan: newerThan ?? undefined,
+    final: finalOnly,
+  })
+
+  if (warnings.length === 0) {
+    return message.reply({
+      embeds: [
+        createSimpleEmbed(
+          target
+            ? `${target} has no warnings matching this search!`
+            : "no warnings matched this search!",
+          color,
+        ),
+      ],
+      allowedMentions: { repliedUser: false },
+    })
+  }
+
+  const pageCount = Math.ceil(warnings.length / WARNINGS_PER_PAGE)
+  if (pageNumber > pageCount) {
+    return message.reply({
+      embeds: [createSimpleEmbed("there are no warnings on this page!", color)],
+      allowedMentions: { repliedUser: false },
+    })
+  }
+
+  const pageStart = (pageNumber - 1) * WARNINGS_PER_PAGE
+  const page = warnings.slice(pageStart, pageStart + WARNINGS_PER_PAGE)
+  const warningsEmbed = new EmbedBuilder()
+    .setTitle(target ? `${target.user.tag}'s warnings` : `${message.guild.name}'s warnings`)
+    .setColor(color)
+    .setFooter({
+      text: `showing ${pageStart + 1}-${pageStart + page.length} of ${warnings.length} warnings (page ${pageNumber}/${pageCount})`,
+    })
+
+  if (target && warnings.some((warning) => warning.final)) {
+    warningsEmbed.setDescription("this member is on their final warning.")
+  }
+
+  for (const warning of page) {
+    const timestamp = Math.floor(new Date(warning.createdAt).getTime() / 1000)
+    const reason = (warning.reason || "no reason provided").slice(0, 850)
+
+    warningsEmbed.addFields({
+      name: `${warning.final ? bot.config.emojis.final_warning : bot.config.emojis.warning} warning ${warning.id}${warning.final ? " - final" : ""}`,
+      value: `<@${warning.to}> - *${reason}*\n<t:${timestamp}>`,
+      inline: true,
+    })
+  }
+
+  return message.reply({
+    embeds: [warningsEmbed],
+    allowedMentions: { repliedUser: false },
+  })
+}
+
+export const config: BaseCommandConfig = {
+  name: "warnings",
+  description: "shows warning history for the server or a member",
+  usage: ["warnings <page>", "warnings <user> <page> [--time <|> duration] [--final]"],
+  aliases: ["warns"],
+  cooldown: 1,
+  permissionSet: {
+    guildOnly: true,
+    userPermissionsRequired: ["ManageMessages"],
+  },
+}

--- a/apps/bot/src/config/config.ts
+++ b/apps/bot/src/config/config.ts
@@ -25,6 +25,9 @@ const Config = {
   emojis: {
     balance: "<:01keys:927172772336136222>",
     balance_loading: "<a:keys_loading:1533807643322482748>",
+    final_warning: "<a:swarning:1089036999962415155>",
+    warning: "<a:2122_exclam:1089034738766974997>",
+    placeholder: "<:zplaceholder:1089034404355129345>",
     return: "↩️",
     reload: "🔃",
     add: "➕",

--- a/apps/bot/src/database/collections/WarnCollection.ts
+++ b/apps/bot/src/database/collections/WarnCollection.ts
@@ -86,18 +86,17 @@ export class WarnCollection {
    * @param userId The ID of the user to clear warns for.
    * @returns The cleared warns.
    */
-  public async clearUserWarns(serverId: string, userId: string): Promise<Warn[]> {
-    const warnings = await this.getServerWarns(serverId, userId)
-
-    await Promise.all(
-      warnings.map((warning) =>
-        this.db.delete({
-          collection: "warns",
-          id: warning.id,
-        }),
-      ),
-    )
-
-    return warnings
+  public async clearUserWarns(serverId: string, userId: string) {
+    return this.db.delete({
+      collection: "warns",
+      where: {
+        server: {
+          equals: serverId,
+        },
+        to: {
+          equals: userId,
+        },
+      },
+    })
   }
 }

--- a/apps/bot/src/database/collections/WarnCollection.ts
+++ b/apps/bot/src/database/collections/WarnCollection.ts
@@ -1,0 +1,103 @@
+import type { Warn } from "@repo/shared/payload-types"
+import type { Payload, Where } from "payload"
+
+export class WarnCollection {
+  private db: Payload
+
+  constructor(db: Payload) {
+    this.db = db
+  }
+
+  /**
+   * Creates a new warn for the specified user on the specified server.
+   *
+   * @param data The data for the warn to be created.
+   * @returns The created warn.
+   */
+  public async createWarn(data: Omit<Warn, "id" | "createdAt" | "updatedAt">): Promise<Warn> {
+    return this.db.create({
+      collection: "warns",
+      data,
+    })
+  }
+
+  /**
+   * Retrieves the warns for the specified user on the specified server.
+   *
+   * @param serverId The ID of the server to get warns for.
+   * @param userId The ID of the user to get warns for.
+   * @returns The user's warns on the server.
+   */
+  public async getServerWarns(serverId: string, userId?: string): Promise<Warn[]> {
+    const where: Where = {
+      server: {
+        equals: serverId,
+      },
+    }
+
+    if (userId) {
+      where.to = {
+        equals: userId,
+      }
+    }
+
+    return (
+      await this.db.find({
+        collection: "warns",
+        where,
+        sort: "-createdAt",
+        depth: 1,
+        pagination: false,
+      })
+    ).docs
+  }
+
+  /**
+   * Checks if the specified user has a final warn on the specified server.
+   *
+   * @param serverId The ID of the server to check.
+   * @param userId The ID of the user to check.
+   * @returns Whether the user has a final warn on the server.
+   */
+  public async hasFinalWarn(serverId: string, userId: string): Promise<boolean> {
+    const result = await this.db.find({
+      collection: "warns",
+      where: {
+        server: {
+          equals: serverId,
+        },
+        to: {
+          equals: userId,
+        },
+        final: {
+          equals: true,
+        },
+      },
+      limit: 1,
+    })
+
+    return result.docs.length > 0
+  }
+
+  /**
+   * Clears all warns for the specified user on the specified server.
+   *
+   * @param serverId The ID of the server to clear warns for.
+   * @param userId The ID of the user to clear warns for.
+   * @returns The cleared warns.
+   */
+  public async clearUserWarns(serverId: string, userId: string): Promise<Warn[]> {
+    const warnings = await this.getServerWarns(serverId, userId)
+
+    await Promise.all(
+      warnings.map((warning) =>
+        this.db.delete({
+          collection: "warns",
+          id: warning.id,
+        }),
+      ),
+    )
+
+    return warnings
+  }
+}

--- a/apps/bot/src/database/collections/WarnCollection.ts
+++ b/apps/bot/src/database/collections/WarnCollection.ts
@@ -123,4 +123,27 @@ export class WarnCollection {
       },
     })
   }
+
+  /**
+   * Removes a warning by ID if it belongs to the specified server.
+   *
+   * @param serverId The ID of the server the warning must belong to.
+   * @param warningId The ID of the warning to remove.
+   * @returns The removed warning, or `undefined` if no matching warning exists.
+   */
+  public async removeServerWarn(serverId: string, warningId: string): Promise<Warn | undefined> {
+    const result = await this.db.delete({
+      collection: "warns",
+      where: {
+        id: {
+          equals: warningId,
+        },
+        server: {
+          equals: serverId,
+        },
+      },
+    })
+
+    return result.docs[0]
+  }
 }

--- a/apps/bot/src/database/collections/WarnCollection.ts
+++ b/apps/bot/src/database/collections/WarnCollection.ts
@@ -26,9 +26,18 @@ export class WarnCollection {
    *
    * @param serverId The ID of the server to get warns for.
    * @param userId The ID of the user to get warns for.
+   * @param filters Optional filters to apply to the warns query.
    * @returns The user's warns on the server.
    */
-  public async getServerWarns(serverId: string, userId?: string): Promise<Warn[]> {
+  public async getServerWarns(
+    serverId: string,
+    userId?: string,
+    filters: {
+      olderThan?: number
+      newerThan?: number
+      final?: boolean
+    } = {},
+  ): Promise<Warn[]> {
     const where: Where = {
       server: {
         equals: serverId,
@@ -40,6 +49,21 @@ export class WarnCollection {
         equals: userId,
       }
     }
+
+    if (filters.olderThan) {
+      where.createdAt = {
+        less_than: new Date(filters.olderThan).toISOString(),
+      }
+    }
+
+    if (filters.newerThan) {
+      where.createdAt = {
+        ...where.createdAt,
+        greater_than: new Date(filters.newerThan).toISOString(),
+      }
+    }
+
+    if (filters.final) where.final = { equals: true }
 
     return (
       await this.db.find({

--- a/apps/bot/src/database/index.ts
+++ b/apps/bot/src/database/index.ts
@@ -3,6 +3,7 @@ import { ConfessionCollection } from "./collections/ConfessionCollection"
 import { ConfessionMutesCollection } from "./collections/ConfessionMutesCollection"
 import { ServerCollection } from "./collections/ServerCollection"
 import { UserCollection } from "./collections/UserCollection"
+import { WarnCollection } from "./collections/WarnCollection"
 import { BotConfigCollection } from "./globals/BotConfigCollection"
 
 export const db = {
@@ -10,6 +11,7 @@ export const db = {
   confessions: new ConfessionCollection(payload),
   servers: new ServerCollection(payload),
   confessionMutes: new ConfessionMutesCollection(payload),
+  warns: new WarnCollection(payload),
   // Globals
   botConfig: new BotConfigCollection(payload),
 }

--- a/apps/bot/src/utils/moderation/index.ts
+++ b/apps/bot/src/utils/moderation/index.ts
@@ -1,0 +1,22 @@
+import type { Message, MessageCreateOptions } from "discord.js"
+import type { db } from "@/database"
+
+export const sendModerationLog = async (
+  message: Message<true>,
+  database: typeof db,
+  options: MessageCreateOptions,
+): Promise<string | null> => {
+  const server = await database.servers.getOrCreateServerByDiscordId(message.guild.id)
+  const channelId = server.notificationSettings?.moderationChannel
+  if (!channelId) return null
+
+  const channel = message.guild.channels.cache.get(channelId)
+  if (!channel?.isSendable()) return null
+
+  const sent = await channel
+    .send(options)
+    .then(() => true)
+    .catch(() => false)
+
+  return sent ? channel.id : null
+}

--- a/apps/bot/src/utils/parsers/members.ts
+++ b/apps/bot/src/utils/parsers/members.ts
@@ -15,6 +15,7 @@ export function getMember({
   message,
   toFind = "",
   excludeSelf = true,
+  excludeNameSearch = false,
 }: GetMemberOptions<boolean>): GuildMember | undefined {
   const lowercaseFind = toFind.toLowerCase()
 
@@ -24,7 +25,7 @@ export function getMember({
 
   if (!target && message.mentions.members) target = message.mentions.members.first()
 
-  if (!target && lowercaseFind) {
+  if (!excludeNameSearch && !target && lowercaseFind) {
     target = message.guild.members.cache.find((member) => {
       return (
         member.displayName.toLowerCase().includes(lowercaseFind) ||

--- a/apps/bot/src/utils/parsers/types.ts
+++ b/apps/bot/src/utils/parsers/types.ts
@@ -14,6 +14,10 @@ export type GetMemberOptions<T extends boolean> = {
    * Fallsback to returning the message's member themselves if nobody was found.
    */
   excludeSelf: T
+  /**
+   * Whether to exclude name search when finding a member.
+   */
+  excludeNameSearch?: boolean
 }
 
 export type GetUserOptions<T extends boolean> = {

--- a/packages/payload/src/collections/Servers.ts
+++ b/packages/payload/src/collections/Servers.ts
@@ -75,6 +75,10 @@ export const Servers: CollectionConfig = {
           name: "bumpChannel",
           type: "text",
         },
+        {
+          name: "moderationChannel",
+          type: "text",
+        },
       ],
     },
     {

--- a/packages/payload/src/collections/Warns.ts
+++ b/packages/payload/src/collections/Warns.ts
@@ -6,17 +6,22 @@ export const Warns: CollectionConfig = {
     {
       name: "reason",
       type: "text",
+      required: true,
     },
     {
       name: "by",
-      type: "relationship",
-      relationTo: "users",
+      type: "text",
+      admin: {
+        description: "The discord user ID",
+      },
       required: true,
     },
     {
       name: "to",
-      type: "relationship",
-      relationTo: "users",
+      type: "text",
+      admin: {
+        description: "The discord user ID",
+      },
       required: true,
     },
     {
@@ -28,6 +33,7 @@ export const Warns: CollectionConfig = {
     {
       name: "final",
       type: "checkbox",
+      defaultValue: false,
     },
   ],
 }

--- a/packages/payload/src/collections/Warns.ts
+++ b/packages/payload/src/collections/Warns.ts
@@ -26,8 +26,10 @@ export const Warns: CollectionConfig = {
     },
     {
       name: "server",
-      type: "relationship",
-      relationTo: "servers",
+      type: "text",
+      admin: {
+        description: "The discord server ID",
+      },
       required: true,
     },
     {

--- a/packages/payload/src/payload.config.ts
+++ b/packages/payload/src/payload.config.ts
@@ -9,6 +9,7 @@ import { ConfessionMutes } from "./collections/ConfessionMutes"
 import { Confessions } from "./collections/Confessions"
 import { Servers } from "./collections/Servers"
 import { Users } from "./collections/Users"
+import { Warns } from "./collections/Warns"
 import { BotConfig } from "./globals/BotConfig"
 
 const filename = fileURLToPath(import.meta.url)
@@ -21,7 +22,7 @@ export default buildConfig({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Admins, Users, Servers, Confessions, ConfessionMutes],
+  collections: [Admins, Users, Servers, Confessions, ConfessionMutes, Warns],
   globals: [BotConfig],
   secret: process.env.PAYLOAD_SECRET || "",
   typescript: {

--- a/packages/shared/src/payload-types.ts
+++ b/packages/shared/src/payload-types.ts
@@ -77,6 +77,7 @@ export interface Config {
     servers: Server;
     confessions: Confession;
     'confession-mutes': ConfessionMute;
+    warns: Warn;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -89,6 +90,7 @@ export interface Config {
     servers: ServersSelect<false> | ServersSelect<true>;
     confessions: ConfessionsSelect<false> | ConfessionsSelect<true>;
     'confession-mutes': ConfessionMutesSelect<false> | ConfessionMutesSelect<true>;
+    warns: WarnsSelect<false> | WarnsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -219,6 +221,7 @@ export interface PhishingImageSettings {
  */
 export interface NotificationSettings {
   bumpChannel?: string | null;
+  moderationChannel?: string | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -276,6 +279,26 @@ export interface ConfessionMute {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "warns".
+ */
+export interface Warn {
+  id: string;
+  reason: string;
+  /**
+   * The discord user ID
+   */
+  by: string;
+  /**
+   * The discord user ID
+   */
+  to: string;
+  server: string | Server;
+  final?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -317,6 +340,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'confession-mutes';
         value: string | ConfessionMute;
+      } | null)
+    | ({
+        relationTo: 'warns';
+        value: string | Warn;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -436,6 +463,7 @@ export interface PhishingImageSettingsSelect<T extends boolean = true> {
  */
 export interface NotificationSettingsSelect<T extends boolean = true> {
   bumpChannel?: T;
+  moderationChannel?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -465,6 +493,19 @@ export interface ConfessionMutesSelect<T extends boolean = true> {
   serverId?: T;
   mutedBy?: T;
   reason?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "warns_select".
+ */
+export interface WarnsSelect<T extends boolean = true> {
+  reason?: T;
+  by?: T;
+  to?: T;
+  server?: T;
+  final?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/packages/shared/src/payload-types.ts
+++ b/packages/shared/src/payload-types.ts
@@ -292,7 +292,10 @@ export interface Warn {
    * The discord user ID
    */
   to: string;
-  server: string | Server;
+  /**
+   * The discord server ID
+   */
+  server: string;
   final?: boolean | null;
   updatedAt: string;
   createdAt: string;


### PR DESCRIPTION
## Description

- Closes #31 

 Adds a complete moderation warning system backed by Payload.

  - Adds commands to issue regular and final warnings.
  - Adds paginated warning history with member, time, and final-warning filters.
  - Adds commands to clear all warnings for a member or remove a specific warning by ID.
  - Sends affected users a DM when warnings are issued, cleared, or removed, while reporting failed deliveries to moderators.
  - Prevents additional warnings after a member receives a final warning.
  - Adds a configurable moderation-log channel to server notification settings.
  - Logs warning actions with moderator, member, reason, and warning details.
  - Adds server-scoped warning persistence and CRUD operations.
  - Updates generated Payload types and warning-related bot configuration.
